### PR TITLE
feat(auth): Implement token verification, refresh, and request interception

### DIFF
--- a/cmd/auth/server.go
+++ b/cmd/auth/server.go
@@ -3,7 +3,9 @@ package auth
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"github.com/getnoops/ops/pkg/tokenstore"
 	"log"
 	"net"
 	"net/http"
@@ -69,6 +71,49 @@ func CodeExchangeHandler[C oidc.IDClaims](callback rp.CodeExchangeCallback[C], p
 	}
 }
 
+// verifier and relyingParty variables needed in verifying the token
+var verifier rp.IDTokenVerifier
+var relyingParty rp.RelyingParty
+
+// VerifyTokenAndReturn verifies the token and handles the case of expiration of token
+// - it will retrieve the tokens from [User Home Directory]/.no_ops/no_opsconfig file
+// - checks whether the token is expired or not, if expired it refreshes and stores the new token
+// - returns the token if they are valid
+// - returns an error for issues in
+//   - retrieving token from file
+//   - verifying token
+//   - refreshing the access token
+//   - storing updated tokens
+func VerifyTokenAndReturn() (*tokenstore.Tokens, error) {
+	token, err := tokenstore.Retrieve()
+	if err != nil {
+		return nil, err
+	}
+
+	// Don't need claims here for now, may need later
+	_, err = rp.VerifyTokens[*oidc.IDTokenClaims](context.Background(), token.AccessToken, token.IDToken, verifier)
+	if err != nil {
+		if errors.Is(err, oidc.ErrExpired) {
+			newAccessToken, refreshAccessTokenErr := rp.RefreshAccessToken(relyingParty, token.RefreshToken, "", "")
+			if refreshAccessTokenErr != nil {
+				return nil, refreshAccessTokenErr
+			}
+			updateTokensErr := tokenstore.UpdateTokens(newAccessToken.AccessToken, newAccessToken.RefreshToken)
+			if updateTokensErr != nil {
+				return nil, updateTokensErr
+			}
+			return &tokenstore.Tokens{
+				AccessToken:  newAccessToken.AccessToken,
+				RefreshToken: newAccessToken.RefreshToken,
+				IDToken:      token.IDToken,
+				TokenType:    token.TokenType,
+			}, nil
+		}
+		return nil, err
+	}
+	return token, nil
+}
+
 func AuthRedirect(provider rp.RelyingParty, state string, codeVerifier string, urlParam ...rp.URLParamOpt) {
 	opts := make([]rp.AuthURLOpt, len(urlParam))
 
@@ -100,6 +145,7 @@ func NewServer(ctx context.Context, config *Config, tokenChan chan *oidc.Tokens[
 
 	provider, err := rp.NewRelyingPartyOIDC(config.Auth.Issuer, config.Auth.ClientId, "", redirectUri, config.Auth.Scopes, options...)
 	logging.OnError(err).Fatal("error creating provider")
+	verifier = provider.IDTokenVerifier()
 
 	callback := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty) {
 		tokenChan <- tokens
@@ -116,7 +162,7 @@ func NewServer(ctx context.Context, config *Config, tokenChan chan *oidc.Tokens[
 	}
 
 	go func() {
-		if err := srv.Serve(l); err != nil && err != http.ErrServerClosed {
+		if err := srv.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logging.OnError(err).Fatal("error starting server")
 		}
 	}()

--- a/cmd/auth/server.go
+++ b/cmd/auth/server.go
@@ -146,6 +146,7 @@ func NewServer(ctx context.Context, config *Config, tokenChan chan *oidc.Tokens[
 	provider, err := rp.NewRelyingPartyOIDC(config.Auth.Issuer, config.Auth.ClientId, "", redirectUri, config.Auth.Scopes, options...)
 	logging.OnError(err).Fatal("error creating provider")
 	verifier = provider.IDTokenVerifier()
+	relyingParty = provider
 
 	callback := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty) {
 		tokenChan <- tokens

--- a/pkg/brain/config.go
+++ b/pkg/brain/config.go
@@ -1,6 +1,7 @@
 package brain
 
 import (
+	"github.com/getnoops/ops/cmd/auth"
 	"net/http"
 	"time"
 )
@@ -8,8 +9,28 @@ import (
 // The global accessible initialised client
 var Client *ClientWithResponses
 
+// TokenInterceptorTransport implementing RoundTripper interface, using
+// this interceptor to add Authorization token header to the request
+type TokenInterceptorTransport struct {
+	Transport http.RoundTripper
+}
+
+func (ti *TokenInterceptorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tokens, err := auth.VerifyTokenAndReturn()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	return ti.Transport.RoundTrip(req)
+}
+
 func InitClient(serverUrl string) error {
-	c := http.Client{Timeout: time.Duration(90) * time.Second}
+	c := http.Client{
+		Transport: &TokenInterceptorTransport{
+			Transport: http.DefaultTransport,
+		},
+		Timeout: time.Duration(90) * time.Second,
+	}
 	newClient, err := NewClientWithResponses(serverUrl, WithHTTPClient(&c))
 
 	if err != nil {

--- a/pkg/tokenstore/token_storage.go
+++ b/pkg/tokenstore/token_storage.go
@@ -1,11 +1,13 @@
 package tokenstore
 
 import (
+	"errors"
 	"fmt"
-	"github.com/zitadel/oidc/v2/pkg/oidc"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/zitadel/oidc/v2/pkg/oidc"
 )
 
 const (
@@ -17,6 +19,7 @@ type Tokens struct {
 	AccessToken  string
 	RefreshToken string
 	TokenType    string
+	IDToken      string
 }
 
 func getNoOpsFolderPath() (string, error) {
@@ -25,6 +28,22 @@ func getNoOpsFolderPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(homeDir, noOpsFolder), nil
+}
+
+func validateTokens(tokens Tokens) error {
+	if tokens.AccessToken == "" {
+		return errors.New("access token not found")
+	}
+	if tokens.RefreshToken == "" {
+		return errors.New("refresh token not found")
+	}
+	if tokens.TokenType == "" {
+		return errors.New("token type not found")
+	}
+	if tokens.IDToken == "" {
+		return errors.New("ID token not found")
+	}
+	return nil
 }
 
 func Store(tokens *oidc.Tokens[*oidc.IDTokenClaims]) error {
@@ -45,8 +64,8 @@ func Store(tokens *oidc.Tokens[*oidc.IDTokenClaims]) error {
 	configFilePath := filepath.Join(noOpsFolderPath, configFileName)
 
 	tokenData := []byte(fmt.Sprintf(
-		"ACCESS_TOKEN=%s\nREFRESH_TOKEN=%s\nTOKEN_TYPE=%s\n",
-		tokens.AccessToken, tokens.RefreshToken, tokens.TokenType))
+		"ACCESS_TOKEN=%s\nREFRESH_TOKEN=%s\nTOKEN_TYPE=%s\nID_TOKEN=%s",
+		tokens.AccessToken, tokens.RefreshToken, tokens.TokenType, tokens.IDToken))
 
 	err = os.WriteFile(configFilePath, tokenData, 0600)
 	if err != nil {
@@ -86,8 +105,57 @@ func Retrieve() (tokens *Tokens, err error) {
 			tokens.RefreshToken = value
 		case "TOKEN_TYPE":
 			tokens.TokenType = value
+		case "ID_TOKEN":
+			tokens.IDToken = value
+		}
+	}
+	err = validateTokens(*tokens)
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+func UpdateTokens(accessToken string, refreshToken string) error {
+	noOpsFolderPath, err := getNoOpsFolderPath()
+	if err != nil {
+		return fmt.Errorf("error getting user's home directory: %v", err)
+	}
+
+	configFilePath := filepath.Join(noOpsFolderPath, configFileName)
+
+	// Read the existing configuration
+	configData, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading 'no_opsconfig' file: %v", err)
+	}
+
+	// Create a map to store the updated key-value pairs
+	updatedConfig := make(map[string]string)
+	for _, line := range strings.Split(string(configData), "\n") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			updatedConfig[key] = parts[1]
 		}
 	}
 
-	return tokens, nil
+	// Update the key-value pairs with the provided tokens
+	updatedConfig["ACCESS_TOKEN"] = accessToken
+	updatedConfig["REFRESH_TOKEN"] = refreshToken
+
+	// Generate the new configuration data
+	var updatedConfigLines []string
+	for key, value := range updatedConfig {
+		updatedConfigLines = append(updatedConfigLines, fmt.Sprintf("%s=%s", key, value))
+	}
+	updatedConfigData := []byte(strings.Join(updatedConfigLines, "\n"))
+
+	// Write the updated configuration back to the file
+	err = os.WriteFile(configFilePath, updatedConfigData, 0600)
+	if err != nil {
+		return fmt.Errorf("error writing updated tokens to 'no_opsconfig' file: %v", err)
+	}
+
+	return nil
 }

--- a/pkg/tokenstore/token_storage.go
+++ b/pkg/tokenstore/token_storage.go
@@ -76,7 +76,7 @@ func Store(tokens *oidc.Tokens[*oidc.IDTokenClaims]) error {
 	return nil
 }
 
-func Retrieve() (tokens *Tokens, err error) {
+func Retrieve() (*Tokens, error) {
 	noOpsFolderPath, err := getNoOpsFolderPath()
 	if err != nil {
 		return nil, fmt.Errorf("error getting user's home directory: %v", err)
@@ -89,6 +89,7 @@ func Retrieve() (tokens *Tokens, err error) {
 		return nil, fmt.Errorf("error reading 'no_opsconfig' file: %v", err)
 	}
 
+	var tokens Tokens
 	lines := strings.Split(string(configData), "\n")
 	for _, line := range lines {
 		parts := strings.SplitN(line, "=", 2)
@@ -109,11 +110,11 @@ func Retrieve() (tokens *Tokens, err error) {
 			tokens.IDToken = value
 		}
 	}
-	err = validateTokens(*tokens)
+	err = validateTokens(tokens)
 	if err != nil {
 		return nil, err
 	}
-	return tokens, nil
+	return &tokens, nil
 }
 
 func UpdateTokens(accessToken string, refreshToken string) error {


### PR DESCRIPTION
Changes implemented in this pull request

- Created a function named `VerifyTokenAndReturn` this function verifies the token and handles the case of expiration of token
   - it will retrieve the tokens from `[User's Home Directory]/.no_ops/no_opsconfig` file
   - checks whether the token is expired or not, if expired it refreshes and stores the new token
   - returns the token if they are valid
   - returns an error for issues in
     - retrieving token from file
     - verifying token 
     - refreshing the access token
     - storing updated tokens
- Implemented `RoundTripper` interface to intercept the request and add `Authorization` header to it. 
